### PR TITLE
Add a call to super within UICollectionViewCell to silence compiler warning in Xcode 9.

### DIFF
--- a/CMTabbarView/Classes/CMTabbarCollectionViewCell.m
+++ b/CMTabbarView/Classes/CMTabbarCollectionViewCell.m
@@ -40,6 +40,7 @@
 {
     self.title = nil;
     self.textColor = nil;
+    [super prepareForReuse];
 }
 
 - (void)awakeFromNib {


### PR DESCRIPTION
In Xcode 9, this produced a warning in my project.  Per apple docs...… "The default implementation of this method does nothing. However, when overriding this method, it is recommended that you call super anyway."